### PR TITLE
Amplify Dependecy Issue

### DIFF
--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.14.5
-  intl: '>=0.15.2 <0.18.0'
+  intl: ^0.18.1
   logging: ^1.0.2
   meta: ^1.1.1
   vector_math: ^2.0.8

--- a/charts_flutter/example/pubspec.yaml
+++ b/charts_flutter/example/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
 dependencies:
   charts_flutter:
     path: ../
-  cupertino_icons: ^0.1.0
+  cupertino_icons: ^1.0.6
   flutter:
     sdk: flutter
   flutter_test:
     sdk: flutter
   meta: ^1.1.1
-  intl: '>=0.15.2 <0.18.0'
+  intl: ^0.18.1
 flutter:
   uses-material-design: true

--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -8,31 +8,25 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
-  # Pointing this to a local path allows for pointing to the latest code
-  # in Github for open source development.
-  #
-  # The pub version of charts_flutter will point to the pub version of charts_common.
-  # The latest pub version is commented out and shown below as an example.
-  #charts_common: ^0.12.0
-  #charts_common:
-  #  path: ../charts_common
+  # Though charts_common and charts_flutter are in the same repo
+  # we still need to reference it by git as if it were in its own
   charts_common:
     git:
       url: https://github.com/devs-emporia/charts.git
       path: charts_common
-      ref: plot_gradient_lines
+      ref: 2023.10.31
 
   collection: ^1.14.5
   flutter:
     sdk: flutter
-  intl: '>=0.15.2 <0.18.0'
+  intl: ^0.18.1
   logging: ^1.0.2
   meta: ^1.1.1
 
 
 dev_dependencies:
   yaml: ^3.0.0
-  analyzer: ^4.1.0
+  analyzer: ^5.13.0
   code_builder: ^4.1.0
   mockito: ^5.2.0
   build_runner:


### PR DESCRIPTION
To use this package in the same codebase as AWS Amplify, we need to upgrade to intl 0.18.1. Also update the ref for charts_common to point to the 2023.10.31 tag which will have intl 0.18.0 in its pubspec. Finally needed to bump cupertino_icons in the example project and analyzer for charts_flutter but neither of those should have any impact on projects using charts_flutter.